### PR TITLE
Added wrapper functions mrfT1 and mrfT2 which can be passed directly to matlabs colormap() function

### DIFF
--- a/mrfT1.m
+++ b/mrfT1.m
@@ -16,7 +16,7 @@ function CMap = mrfT1(customMap)
 %   See also COLORMAP
 
     % define which .mat file to load
-    if (nargin < 1)
+    if (nargin < 1) || (isnumeric(customMap))
         mapFile = 'T1cm.mat';
     else
         mapFile = customMap;

--- a/mrfT1.m
+++ b/mrfT1.m
@@ -1,0 +1,35 @@
+function CMap = mrfT1(customMap)
+%MRFT1    loads the T1 colormaps for magnetic resonance finterprinting
+%   MRFT1() returns an M-by-3 matrix containing a T1 colormap optimized
+%   for magnetic resonance fingerprinting as introduced by 
+%   Griswold et al at ISMRM 2018
+%   
+%   MRFT1(customMap) loads one of the given variations of the T1 colormaps,
+%   according to Obmann et al at ISMRM 2019. Possitble custom maps are:
+%       'T1cm','T1_v1','T1_v2','T1_v3'
+%
+%   This function can be passed directly to the colormap method of matlab
+%   
+%       colormap(mrfT1);
+%       colormap(mrfT1('T2_v1'));
+%
+%   See also COLORMAP
+
+    % define which .mat file to load
+    if (nargin < 1)
+        mapFile = 'T1cm.mat';
+    else
+        mapFile = customMap;
+    end
+    
+    % load mat file and get fields
+    try
+        map = load(mapFile);
+    catch
+        map = load(fullfile('Obmann et al', mapFile));
+    end
+    mapFields = fields(map);
+    
+    % assign to output
+    CMap = map.(mapFields{1});
+end

--- a/mrfT2.m
+++ b/mrfT2.m
@@ -16,7 +16,7 @@ function CMap = mrfT2(customMap)
 %   See also COLORMAP
 
     % define which .mat file to load
-    if (nargin < 1)
+    if (nargin < 1) || (isnumeric(customMap))
         mapFile = 'T2cm.mat';
     else
         mapFile = customMap;
@@ -25,7 +25,7 @@ function CMap = mrfT2(customMap)
     % load mat file and get fields
     try
         map = load(mapFile);
-    catch
+    catch        
         map = load(fullfile('Obmann et al', mapFile));
     end
     mapFields = fields(map);

--- a/mrfT2.m
+++ b/mrfT2.m
@@ -1,0 +1,35 @@
+function CMap = mrfT2(customMap)
+%MRFT2    loads the T2 colormaps for magnetic resonance finterprinting
+%   MRFT2() returns an M-by-3 matrix containing a T2 colormap optimized
+%   for magnetic resonance fingerprinting as introduced by 
+%   Griswold et al at ISMRM 2018
+%   
+%   MRFT2(customMap) loads one of the given variations of the T2 colormaps,
+%   according to Obmann et al at ISMRM 2019. Possitble custom maps are:
+%       'T2cm','T2_v1','T2_v2','T2_v3'
+%
+%   This function can be passed directly to the colormap method of matlab
+%   
+%       colormap(mrfT2);
+%       colormap(mrfT2('T2_v1'));
+%
+%   See also COLORMAP
+
+    % define which .mat file to load
+    if (nargin < 1)
+        mapFile = 'T2cm.mat';
+    else
+        mapFile = customMap;
+    end
+    
+    % load mat file and get fields
+    try
+        map = load(mapFile);
+    catch
+        map = load(fullfile('Obmann et al', mapFile));
+    end
+    mapFields = fields(map);
+    
+    % assign to output
+    CMap = map.(mapFields{1});
+end


### PR DESCRIPTION
Since the color maps are at the moment only given as .mat files I created two wrapper functions mrfT1 and mrfT2 which load the .mat files and return the colormaps as an output. By doing so the colormaps can be directly passed to matlabs colormap() function. 

The functions also have an optional parameter to load the colormaps provided by Obmann et al at ISMRM 2019, see example below

as example:
```matlab
% load T2cm colormap from Griswold et al at ISMRM 2018
colormap(mrfT2);

% load T2_v1 colormap from Obmann et al at ISMRM 2019
colormap(mrfT1('T1_v1'))
```